### PR TITLE
implement patch by Bill Allombert 2022/03/03

### DIFF
--- a/doc/radiroot.tex
+++ b/doc/radiroot.tex
@@ -151,8 +151,6 @@ session.
 
 The computation may take a very long time and can get unfeasible if the
 degree of <f> is greater than 7.
-\beginexample
-\endexample
 
 \> RootsOfPolynomialAsRadicalsNC( <f> [, <mode> [, <file> ] ] )
 


### PR DESCRIPTION
this is a trivial removal of an empty example:

```diff
--- gap-radiroot-2.9.orig/doc/radiroot.tex                                             
+++ gap-radiroot-2.9/doc/radiroot.tex                                                  
@@ -151,8 +151,6 @@ session.                                                           
                                                                                       
 The computation may take a very long time and can get unfeasible if the               
 degree of <f> is greater than 7.                                                      
-\beginexample                                                                         
-\endexample                                                                           
                                                                                       
 \> RootsOfPolynomialAsRadicalsNC( <f> [, <mode> [, <file> ] ] )                       
```